### PR TITLE
Make "data" and "summary" mutually exclusive in "DecodedNotificationPayload" type

### DIFF
--- a/src/Models.ts
+++ b/src/Models.ts
@@ -211,32 +211,32 @@ export enum OrderLookupStatus {
 
 // https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2decodedpayload
 interface DecodedNotificationBasePayload {
-  notificationType: NotificationType;
-  subtype?: NotificationSubtype;
-  notificationUUID: string;
-  version: string;
-  signedDate: Timestamp;
+  notificationType: NotificationType
+  subtype?: NotificationSubtype
+  notificationUUID: string
+  version: string
+  signedDate: Timestamp
 }
 interface DecodedNotificationDataPayload extends DecodedNotificationBasePayload {
-  data: NotificationData;
-  summary?: never;
+  data: NotificationData
+  summary?: never
 }
-interface DecodedNotificationSummaryPayload extends DecodedNotificationBasePayload{
-  data?: never;
-  summary: NotificationSummary;
+interface DecodedNotificationSummaryPayload extends DecodedNotificationBasePayload {
+  data?: never
+  summary: NotificationSummary
 }
-export type DecodedNotificationPayload = DecodedNotificationDataPayload | DecodedNotificationSummaryPayload;
+export type DecodedNotificationPayload = DecodedNotificationDataPayload | DecodedNotificationSummaryPayload
 
 export function isDecodedNotificationDataPayload(
-  decodedNotificationPayload: DecodedNotificationPayload,
+  decodedNotificationPayload: DecodedNotificationPayload
 ): decodedNotificationPayload is DecodedNotificationDataPayload {
-  return 'data' in decodedNotificationPayload;
+  return "data" in decodedNotificationPayload
 }
 
 export function isDecodedNotificationSummaryPayload(
-  decodedNotificationPayload: DecodedNotificationPayload,
+  decodedNotificationPayload: DecodedNotificationPayload
 ): decodedNotificationPayload is DecodedNotificationSummaryPayload {
-  return 'summary' in decodedNotificationPayload;
+  return "summary" in decodedNotificationPayload
 }
 
 // https://developer.apple.com/documentation/appstoreservernotifications/data

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -227,6 +227,12 @@ interface DecodedNotificationSummaryPayload extends DecodedNotificationBasePaylo
 }
 export type DecodedNotificationPayload = DecodedNotificationDataPayload | DecodedNotificationSummaryPayload;
 
+export function isDecodedNotificationDataPayload(
+  decodedNotificationPayload: DecodedNotificationPayload,
+): decodedNotificationPayload is DecodedNotificationDataPayload {
+  return 'data' in decodedNotificationPayload;
+}
+
 // https://developer.apple.com/documentation/appstoreservernotifications/data
 export interface NotificationData {
   appAppleId: string

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -210,15 +210,22 @@ export enum OrderLookupStatus {
 }
 
 // https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2decodedpayload
-export interface DecodedNotificationPayload {
-  notificationType: NotificationType
-  subtype?: NotificationSubtype
-  notificationUUID: string
-  version: string
-  signedDate: Timestamp
-  data: NotificationData
-  summary: NotificationSummary
+interface DecodedNotificationBasePayload {
+  notificationType: NotificationType;
+  subtype?: NotificationSubtype;
+  notificationUUID: string;
+  version: string;
+  signedDate: Timestamp;
 }
+interface DecodedNotificationDataPayload extends DecodedNotificationBasePayload {
+  data: NotificationData;
+  summary?: never;
+}
+interface DecodedNotificationSummaryPayload extends DecodedNotificationBasePayload{
+  data?: never;
+  summary: NotificationSummary;
+}
+export type DecodedNotificationPayload = DecodedNotificationDataPayload | DecodedNotificationSummaryPayload;
 
 // https://developer.apple.com/documentation/appstoreservernotifications/data
 export interface NotificationData {

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -233,6 +233,12 @@ export function isDecodedNotificationDataPayload(
   return 'data' in decodedNotificationPayload;
 }
 
+export function isDecodedNotificationSummaryPayload(
+  decodedNotificationPayload: DecodedNotificationPayload,
+): decodedNotificationPayload is DecodedNotificationSummaryPayload {
+  return 'summary' in decodedNotificationPayload;
+}
+
 // https://developer.apple.com/documentation/appstoreservernotifications/data
 export interface NotificationData {
   appAppleId: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export {
   OrderLookupStatus,
   DecodedNotificationPayload,
   isDecodedNotificationDataPayload,
+  isDecodedNotificationSummaryPayload,
   NotificationData,
   NotificationSummary,
   NotificationType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export {
   OrderLookupResponse,
   OrderLookupStatus,
   DecodedNotificationPayload,
+  isDecodedNotificationDataPayload,
   NotificationData,
   NotificationSummary,
   NotificationType,


### PR DESCRIPTION
This pull request addresses issue #24.

### Problem
During testing, we encountered an issue where the `DecodedNotificationPayload` type cannot be used effectively to generate notification mocks for testing purposes. This limitation hinders our ability to create accurate test scenarios for handling Apple notifications.
![Screenshot 2023-08-01 at 11 45 32](https://github.com/agisboye/app-store-server-api/assets/19715763/a405deba-e28f-44c7-a63a-45acdc42338e)

To solve that, we have to do some typing trick like this:
```typescript
export const appleTestSubscribedNotification: DecodedNotificationPayload = {
  data: {
    status: 1,
    bundleId: 'com.example.example',
    appAppleId: '9999999999',
    environment: Environment.Sandbox,
    bundleVersion: 594,
    signedRenewalInfo: 'signedRenewalInfo...',
    signedTransactionInfo: 'signedTransactionInfo...',
  },
  summary: {} as NotificationSummary, // <- This feels a bit hacky
  subtype: NotificationSubtype.Resubscribe,
  version: '2.0',
  signedDate: 1690819907859,
  notificationType: NotificationType.Subscribed,
  notificationUUID: '3e6e95be-b09d-4afb-ac10-e4d2c594a9e3',
};
```

### Proposed Solution
I propose a solution to improve the `DecodedNotificationPayload` type, enabling seamless utilization of the new `summary` field and facilitating the convenient generation of notification mocks for testing purposes.

### Changes Made
1. **Updated Typed Payload**: I have improved the `DecodedNotificationPayload` type to better represent the Apple notification data payload according to the official documentation.

2. **Type Guard Function**: I have introduced a type guard function called `isDecodedNotificationDataPayload`. This function can be used to mitigate potential breaking changes and allow users to safely access the `data` (`isDecodedNotificationDataPayload`) and `summary` (`!isDecodedNotificationDataPayload`) properties.

### Additional Notes
I understand that there may be concerns about the placement of the type guard function in `Models.ts`. If you believe that a different file would be more suitable, please feel free to move it accordingly or revert the commit if it is deemed unnecessary.

Thank you for your time, we find the library very useful ❤️. Looking forward to your review and feedback on this pull request.