### PR TITLE
export "DecodedNotificationDataPayload" and "DecodedNotificationSummaryPayload"

### DIFF
--- a/src/Models.ts
+++ b/src/Models.ts
@@ -218,12 +218,12 @@ interface DecodedNotificationBasePayload {
   signedDate: Timestamp
 }
 
-interface DecodedNotificationDataPayload extends DecodedNotificationBasePayload {
+export interface DecodedNotificationDataPayload extends DecodedNotificationBasePayload {
   data: NotificationData
   summary?: never
 }
 
-interface DecodedNotificationSummaryPayload extends DecodedNotificationBasePayload {
+export interface DecodedNotificationSummaryPayload extends DecodedNotificationBasePayload {
   data?: never
   summary: NotificationSummary
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ export {
   OrderLookupResponse,
   OrderLookupStatus,
   DecodedNotificationPayload,
+  DecodedNotificationDataPayload,
+  DecodedNotificationSummaryPayload,
   isDecodedNotificationDataPayload,
   isDecodedNotificationSummaryPayload,
   NotificationData,


### PR DESCRIPTION
Hi August!

We found it useful to export the concrete types `DecodedNotificationDataPayload` and `DecodedNotificationSummaryPayload`. This allows us to use a type guard function and then utilise these types as input parameters, for instance.

```typescript
const normalizeAppleV2DataNotification = async (
  notification: DecodedNotificationDataPayload, // <- Here, we used the type guard before calling this function, and now we want to directly use the concrete type
): Promise<AppleNormalizedNotificationV2> => {
  // If we don't export the concrete types, we have to type the param as "DecodedNotificationPayload" and use the type guard function here again
  const transactionInfo = await decodeTransaction(
    notification.data.signedTransactionInfo,
  );

  const renewalInfo = await decodeRenewalInfo(
    notification.data.signedRenewalInfo,
  );

  const startTime = new Date(Number(transactionInfo.purchaseDate));
  // The implementation continues from here...
}
```

Apologies for not considering this in the previous pull request. Thank you once again for your hard work!