### PR TITLE
make "signedRenewalInfo" optional in "NotificationData"

### DIFF
--- a/src/Models.ts
+++ b/src/Models.ts
@@ -248,7 +248,7 @@ export interface NotificationData {
   bundleId: string
   bundleVersion: number
   environment: Environment
-  signedRenewalInfo: JWSRenewalInfo
+  signedRenewalInfo?: JWSRenewalInfo
   signedTransactionInfo: JWSTransaction
   status?: SubscriptionStatus
 }


### PR DESCRIPTION
Hi August!

The `signedRenewalInfo` is only present in App Store Server Notifications V2 for auto-renewable subscriptions. It is the same case as `status` that it is already optional.

According to the [documentation](https://developer.apple.com/documentation/appstoreservernotifications/data):
> Subscription renewal information signed by the App Store, in JSON Web Signature (JWS) format. **This field appears only for notifications sent for auto-renewable subscriptions.**

So we can safely decode this field checking if it is present first.