### PR TITLE
App store server api version 1.10 changes

### DIFF
--- a/src/Models.ts
+++ b/src/Models.ts
@@ -71,14 +71,17 @@ export interface JWSDecodedHeader {
 export interface JWSTransactionDecodedPayload {
   appAccountToken?: string
   bundleId: string
+  currency: string
   environment: Environment
   expiresDate?: Timestamp
   inAppOwnershipType: OwnershipType
   isUpgraded?: boolean
+  offerDiscountType?: OfferDiscountType
   offerIdentifier?: string
   offerType?: OfferType
   originalPurchaseDate: Timestamp
   originalTransactionId: string
+  price: number
   productId: string
   purchaseDate: Timestamp
   quantity: number
@@ -92,6 +95,13 @@ export interface JWSTransactionDecodedPayload {
   transactionReason: TransactionReason
   type: TransactionType
   webOrderLineItemId: string
+}
+
+// https://developer.apple.com/documentation/appstoreserverapi/offerdiscounttype
+export enum OfferDiscountType {
+  FreeTrail = "FREE_TRIAL",
+  PayAsYouGo = "PAY_AS_YOU_GO",
+  PayUpFront = "PAY_UP_FRONT"
 }
 
 // https://developer.apple.com/documentation/appstoreserverapi/inappownershiptype


### PR DESCRIPTION
Hi,

the new version 1.10 of the App Store Server API was released at 2023/10/26.

There were added some new properties to the the `JWSTransactionDecodedPayload`, see [changelog](https://developer.apple.com/documentation/appstoreserverapi/app_store_server_api_changelog#4307459):

> New features
>
> * Added the following new properties in the decoded transaction payload [JWSTransactionDecodedPayload]>(https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload): [price](https://developer.apple.com/documentation/appstoreserverapi/price), [currency](https://developer.apple.com/documentation/appstoreserverapi/currency), and [offerDiscountType](https://developer.apple.com/documentation/appstoreserverapi/offerdiscounttype).