### PR TITLE
feat: Add PRODUCT_NOT_FOR_SALE subtype

### DIFF
--- a/src/Models.ts
+++ b/src/Models.ts
@@ -306,6 +306,7 @@ export enum NotificationSubtype {
   Voluntary = "VOLUNTARY",
   BillingRetry = "BILLING_RETRY",
   PriceIncrease = "PRICE_INCREASE",
+  ProductNotForSale = "PRODUCT_NOT_FOR_SALE",
   GracePeriod = "GRACE_PERIOD",
   BillingRecovery = "BILLING_RECOVERY",
   Pending = "PENDING",


### PR DESCRIPTION
```Applies to the EXPIRED notificationType. A notification with this subtype indicates that the subscription expired because the product wasn’t available for purchase at the time the subscription attempted to renew.```