### PR TITLE
feat: Change x509 cert validation to use node-agnostic library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "license": "MIT",
       "dependencies": {
         "jose": "^4.14.4",
+        "jsrsasign": "^11.1.0",
         "node-fetch": "^2.6.11",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@types/jsrsasign": "^10.5.12",
         "@types/node-fetch": "^2.6.4",
         "@types/uuid": "^9.0.1",
         "prettier": "^2.8.8",
@@ -80,6 +82,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
+    "node_modules/@types/jsrsasign": {
+      "version": "10.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jsrsasign/-/jsrsasign-10.5.12.tgz",
+      "integrity": "sha512-sOA+eVnHU+FziThpMhuqs/tjFKe5gHVJKIS7g1BzhXP+e2FS8OvtzM0K3IzFxVksDOr98Gz5FJiZVxZ9uFoHhw==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -193,6 +201,14 @@
       "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/jsrsasign": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-11.1.0.tgz",
+      "integrity": "sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==",
+      "funding": {
+        "url": "https://github.com/kjur/jsrsasign#donations"
       }
     },
     "node_modules/make-error": {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
   },
   "dependencies": {
     "jose": "^4.14.4",
+    "jsrsasign": "^11.1.0",
     "node-fetch": "^2.6.11",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/jsrsasign": "^10.5.12",
     "@types/node-fetch": "^2.6.4",
     "@types/uuid": "^9.0.1",
     "prettier": "^2.8.8",


### PR DESCRIPTION
`app-store-server-api` currently doesn't run on platforms like Vercel edge runtime and Cloudflare workers. The blocker was the use of the node `crypto` package to validate the x509 certificates.

Switched to using `jsrsasign`, a simple and popular x509 certificate library, to read the pem files into memory and validate date, chain, and fingerprint.