### PR TITLE
Adds retry after header

### DIFF
--- a/src/AppStoreServerAPI.ts
+++ b/src/AppStoreServerAPI.ts
@@ -161,7 +161,12 @@ export class AppStoreServerAPI {
       case 429:
       case 500:
         const body = await result.json()
-        throw new AppStoreError(body.errorCode, body.errorMessage)
+        let retryAfter: number | undefined
+        let retryAfterHeader = result.headers.get('retry-after')
+        if (result.status === 429 && retryAfterHeader !== null) {
+          retryAfter = parseInt(retryAfterHeader)
+        }
+        throw new AppStoreError(body.errorCode, body.errorMessage, { retryAfter })
 
       case 401:
         this.token = undefined

--- a/src/AppStoreServerAPI.ts
+++ b/src/AppStoreServerAPI.ts
@@ -166,7 +166,7 @@ export class AppStoreServerAPI {
         if (result.status === 429 && retryAfterHeader !== null) {
           retryAfter = parseInt(retryAfterHeader)
         }
-        throw new AppStoreError(body.errorCode, body.errorMessage, { retryAfter })
+        throw new AppStoreError(body.errorCode, body.errorMessage, retryAfter)
 
       case 401:
         this.token = undefined

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -13,15 +13,17 @@ export class AppStoreError extends Error {
 
   errorCode: number
   isRetryable: boolean
+  retryAfter?: number
 
   // https://developer.apple.com/documentation/appstoreserverapi/ratelimitexceedederror
   isRateLimitExceeded: boolean
 
-  constructor(errorCode: number, errorMessage: string) {
+  constructor(errorCode: number, errorMessage: string, { retryAfter}:{ retryAfter?: number } = {}) {
     super(errorMessage)
     this.errorCode = errorCode
     this.isRetryable = AppStoreError.RETRYABLE_ERRORS.includes(errorCode)
     this.isRateLimitExceeded = errorCode === 4290000
+    this.retryAfter = retryAfter
   }
 }
 

--- a/src/Errors.ts
+++ b/src/Errors.ts
@@ -18,7 +18,7 @@ export class AppStoreError extends Error {
   // https://developer.apple.com/documentation/appstoreserverapi/ratelimitexceedederror
   isRateLimitExceeded: boolean
 
-  constructor(errorCode: number, errorMessage: string, { retryAfter}:{ retryAfter?: number } = {}) {
+  constructor(errorCode: number, errorMessage: string, retryAfter?: number) {
     super(errorMessage)
     this.errorCode = errorCode
     this.isRetryable = AppStoreError.RETRYABLE_ERRORS.includes(errorCode)


### PR DESCRIPTION
Following https://developer.apple.com/documentation/appstoreserverapi/identifying_rate_limits, I added the retry after to the error so the client can respect the rate limit correctly. 