### PR TITLE
feat: remove "uuid" dependency and use "crypto.randomUUID" for nonce generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "jose": "^4.15.7",
-        "node-fetch": "^2.7.0",
-        "uuid": "^9.0.1"
+        "node-fetch": "^2.7.0"
       },
       "devDependencies": {
         "@types/node-fetch": "^2.6.11",
-        "@types/uuid": "^9.0.8",
         "prettier": "^2.8.8",
         "ts-node": "^10.9.2",
         "typescript": "^4.9.5"
@@ -100,12 +98,6 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
     },
     "node_modules/acorn": {
       "version": "8.12.0",
@@ -328,18 +320,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,10 @@
   },
   "dependencies": {
     "jose": "^4.15.7",
-    "node-fetch": "^2.7.0",
-    "uuid": "^9.0.1"
+    "node-fetch": "^2.7.0"
   },
   "devDependencies": {
     "@types/node-fetch": "^2.6.11",
-    "@types/uuid": "^9.0.8",
     "prettier": "^2.8.8",
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5"

--- a/src/AppStoreServerAPI.ts
+++ b/src/AppStoreServerAPI.ts
@@ -1,6 +1,6 @@
 import * as jose from "jose"
 import fetch from "node-fetch"
-import { v4 as uuidv4 } from "uuid"
+import { randomUUID } from "crypto"
 import { AppStoreError } from "./Errors"
 import {
   CheckTestNotificationResponse,
@@ -191,7 +191,7 @@ export class AppStoreServerAPI {
 
     const payload = {
       bid: this.bundleId,
-      nonce: uuidv4()
+      nonce: randomUUID()
     }
 
     const privateKey = await this.key


### PR DESCRIPTION
since node 15.6.0 `crypto.randomUUID` allow us to create uuid v4